### PR TITLE
Datastorage bugfix

### DIFF
--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -636,7 +636,7 @@ class TextDataStorage(DataStorageBase):
                                  dtype=dtype,
                                  comments=general['comments'],
                                  delimiter=general['delimiter'],
-                                 skip_header=header_lines + 2)
+                                 skip_header=header_lines + 1)
         except UnicodeError as err:
             raise ValueError(f'Loading data from file "{file_path}" failed. The file you are '
                              f'trying to load is most likely no unicode textfile.') from err


### PR DESCRIPTION
## Description
Fixed TextDataStorage loading one line less than intended. This happened because the first line of data was interpreted as being part of the header.

## Motivation and Context
Bugfix

## How Has This Been Tested?
Tested by saving / loading a dataset and comparing.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
